### PR TITLE
Instrument Aliases

### DIFF
--- a/app/models/encounter/fluid_tracker.rb
+++ b/app/models/encounter/fluid_tracker.rb
@@ -2,42 +2,42 @@ class Encounter::FluidTracker
  attr_reader :own_on_barrier, :other_on_barrier, :own_on_instrument, :other_on_instrument
 
  def initialize(inst, person)
- 	@own_on_barrier = []
- 	@own_on_instrument = []
- 	@other_on_barrier = []
- 	@other_on_instrument = []
- 	@inst = inst
- 	@person = person
+	@own_on_barrier = []
+	@own_on_instrument = []
+	@other_on_barrier = []
+	@other_on_instrument = []
+	@inst = inst
+	@person = person
  end
 
  def track_before(contact, is_subject)
- 	if @inst.can_clean && contact.barriers.include?(is_subject ? :clean_subject : :clean_object)
- 		@own_on_instrument = []
- 		@other_on_instrument = []
- 	elsif contact.barriers.include?(:fresh)
- 		@other_on_barrier = []
- 		@own_on_barrier = []
- 	end
+	if @inst.can_clean && contact.barriers.include?(is_subject ? :clean_subject : :clean_object)
+		@own_on_instrument = []
+		@other_on_instrument = []
+	elsif contact.barriers.include?(:fresh)
+		@other_on_barrier = []
+		@own_on_barrier = []
+	end
  end
 
  def track_after(contact, other_inst)
- 	return unless other_inst.has_fluids
- 	lst = get_list(contact, contact.is_self?)
- 	lst << other_inst._id
+	return unless other_inst.has_fluids
+	lst = get_list(contact, contact.is_self?)
+	lst << other_inst.alias_name
  end
 
  def fluids_present?(contact)
- 	# TODO account for own anal bacteria in vagina
- 	lst = get_list(contact, !contact.is_self?)
- 	lst.any?
+	# TODO account for own anal bacteria in vagina
+	lst = get_list(contact, !contact.is_self?)
+	lst.any?
  end
 
  private
  def get_list(contact, self_state)
- 	if contact.has_barrier?
- 		return self_state ? @own_on_barrier : @other_on_barrier
- 	else
- 		return self_state ? @own_on_instrument : @other_on_instrument
- 	end
+	if contact.has_barrier?
+		return self_state ? @own_on_barrier : @other_on_barrier
+	else
+		return self_state ? @own_on_instrument : @other_on_instrument
+	end
  end
 end

--- a/app/models/encounter/risk_calculator.rb
+++ b/app/models/encounter/risk_calculator.rb
@@ -1,119 +1,121 @@
 class Encounter::RiskCalculator
 	attr_reader :risk_map
 
-  def initialize(encounter)
-  	@encounter = encounter
-    @person = :user
+	def initialize(encounter)
+		@encounter = encounter
+		@person = :user
 
-  	#get resources
-  	@diagnoses = Diagnosis.as_map
-  	@possibles = PossibleContact.as_map
-  	@instruments = Contact::Instrument.as_map
-  	@risks = Diagnosis::TransmissionRisk.grouped_by(:possible_contact_id)
+		#get resources
+		@diagnoses = Diagnosis.as_map
+		@possibles = PossibleContact.as_map
+		@instruments = Contact::Instrument.as_map
+		@risks = Diagnosis::TransmissionRisk.grouped_by(:possible_contact_id)
 
-  	#make tracking maps
-  	@fluid_map = {
-  		partner: Hash.new { |hsh, key| hsh[key] = Encounter::FluidTracker.new(@instruments[key], :partner) },
-  		user: Hash.new { |hsh, key| hsh[key] = Encounter::FluidTracker.new(@instruments[key], :user) },
-  	}
-  	@risk_map = Hash.new(0)
-    @base_risk = 0
-  end
+		#make tracking maps
+		@fluid_map = {
+			partner: Hash.new { |hsh, key| hsh[key] = Encounter::FluidTracker.new(@instruments[key], :partner) },
+			user: Hash.new { |hsh, key| hsh[key] = Encounter::FluidTracker.new(@instruments[key], :user) },
+		}
+		@risk_map = Hash.new(0)
+		@base_risk = 0
+	end
 
-  def track(person = nil, force: false)
-  	return unless @diagnoses.present?
-    return unless force || @encounter.risks.empty?
-  	@person = person if person.present?
-    @base_risk = case @person
-      when :user
-        @encounter.partnership.risk_mitigator
-      when :partner
-        @encounter.partnership.user_profile.risk_mitigator
-      end
-  	@encounter.contacts.each {|c| track_contact(c)}
-  	@encounter.set_risks @risk_map
-    @encounter.set_schedule schedule(force)
-  end
+	def track(person = nil, force: false)
+		return unless @diagnoses.present?
+		return unless force || @encounter.risks.empty?
+		@person = person if person.present?
+		@base_risk = case @person
+			when :user
+				@encounter.partnership.risk_mitigator
+			when :partner
+				@encounter.partnership.user_profile.risk_mitigator
+			end
+		@encounter.contacts.each {|c| track_contact(c)}
+		@encounter.set_risks @risk_map
+		@encounter.set_schedule schedule(force)
+	end
 
-  def schedule(force = false)
-    @risk_map.each_with_object({}) do |(diag_id, diag_risk), h|
-      diag = @diagnoses[diag_id]
-      #recommend a test date for low to high risks
-      test_date = if force || diag_risk > Diagnosis::TransmissionRisk::ROUTINE_TEST_RISK
-        @encounter.took_place + diag.best_test.weeks
-      else
-        #recommend waiting until routine testing for negligible and no risks
-        :routine
-      end
-      h[test_date] ||= []
-      h[test_date] << diag.name
-    end
-  end
+	def schedule(force = false)
+		@risk_map.each_with_object({}) do |(diag_id, diag_risk), h|
+			diag = @diagnoses[diag_id]
+			#recommend a test date for low to high risks
+			test_date = if force || diag_risk > Diagnosis::TransmissionRisk::ROUTINE_TEST_RISK
+				@encounter.took_place + diag.best_test.weeks
+			else
+				#recommend waiting until routine testing for negligible and no risks
+				:routine
+			end
+			h[test_date] ||= []
+			h[test_date] << diag.name
+		end
+	end
 
-  def track_contact(contact)
-  	@cur_contact = contact
-  	@cur_possible = @possibles[contact.possible_contact_id]
-  	@cur_keys = contact_keys
-  	# get where the fluids are before this contact began
-  	fluids_present = get_fluids(true)
-    contact_risks = @risks[@cur_possible.id]
+	def track_contact(contact)
+		@cur_contact = contact
+		@cur_possible = @possibles[contact.possible_contact_id]
+		@cur_keys = contact_keys
+		# get where the fluids are before this contact began
+		fluids_present = get_fluids(true)
+		contact_risks = @risks[@cur_possible.id]
 
-  	unless !contact_risks || (contact.is_self? && contact.subject != @person)
-	  	contact_risks.each do |risk|
-	  		#we're looking for the highest risk in the encounter, so if the risk is already listed as high, don't bother calculating
-	  		old_lvl = @risk_map[risk.diagnosis_id]
-	  		# break if old_lvl == Diagnosis::TransmissionRisk::HIGH
+		unless !contact_risks || (contact.is_self? && contact.subject != @person)
+			contact_risks.each do |risk|
+				#we're looking for the highest risk in the encounter, so if the risk is already listed as high, don't bother calculating
+				old_lvl = @risk_map[risk.diagnosis_id]
+				# break if old_lvl == Diagnosis::TransmissionRisk::HIGH
 
-	  		diag = @diagnoses[risk.diagnosis_id]
-	  		diag_fluids_present = fluids_present && diag.in_fluids
+				diag = @diagnoses[risk.diagnosis_id]
+				diag_fluids_present = fluids_present && diag.in_fluids
 
-	  		lvl = nil
-	  		# if it's user to user-self and there aren't fluids on the barrier or instrument, it's no risk
-	  		if contact.is_self? && !diag_fluids_present
-	  			lvl = Diagnosis::TransmissionRisk::NO_RISK
-  			# if barriers are effective and a barrier was used and there are no fluids on the barrier or the infection isn't in fluids, it's low risk
-	  		elsif risk.barriers_effective && contact.has_barrier? && !diag_fluids_present
-	  			lvl = Diagnosis::TransmissionRisk::NEGLIGIBLE
-	  		# apply the recorded risk, and bump it if there are fluids
-	  		else
-	  			lvl = risk.risk_to_person(contact, diag_fluids_present, @person)
-          # mitigate risk by the base risk of the partnership, but do not go lower than negligible if tracking risk to the user
-          lvl -= @base_risk
+				lvl = nil
+				# if it's user to user-self and there aren't fluids on the barrier or instrument, it's no risk
+				if contact.is_self? && !diag_fluids_present
+					lvl = Diagnosis::TransmissionRisk::NO_RISK
+				# if barriers are effective and a barrier was used and there are no fluids on the barrier or the infection isn't in fluids, it's low risk
+				elsif risk.barriers_effective && contact.has_barrier? && !diag_fluids_present
+					lvl = Diagnosis::TransmissionRisk::NEGLIGIBLE
+				# apply the recorded risk, and bump it if there are fluids
+				else
+					lvl = risk.risk_to_person(contact, diag_fluids_present, @person)
+					# mitigate risk by the base risk of the partnership, but do not go lower than negligible if tracking risk to the user
+					lvl -= @base_risk
 
-          min = @person == :user ? Diagnosis::TransmissionRisk::NEGLIGIBLE : Diagnosis::TransmissionRisk::NO_RISK
+					min = @person == :user ? Diagnosis::TransmissionRisk::NEGLIGIBLE : Diagnosis::TransmissionRisk::NO_RISK
 
-          lvl = lvl > min ? lvl : min
-	  		end
+					lvl = lvl > min ? lvl : min
+				end
 
-	  		contact.set_risk(risk.diagnosis_id,lvl)
-	  		# apply the max risk
-	  		@risk_map[risk.diagnosis_id] = lvl if lvl > old_lvl
-	  	end
-	  end
+				contact.set_risk(risk.diagnosis_id,lvl)
+				# apply the max risk
+				@risk_map[risk.diagnosis_id] = lvl if lvl > old_lvl
+			end
+		end
 
-	  #get where fluids are after this contact ended
-	  get_fluids(false)
-  end
+		#get where fluids are after this contact ended
+		get_fluids(false)
+	end
 
-  def get_fluids(is_before)
-  	fluids_present = false
-  	@cur_keys.each do |k|
-  		person, inst_id, is_subject, other_inst = k
-  		tracker = @fluid_map[person][inst_id]
-  		if is_before
-  			tracker.track_before(@cur_contact, is_subject)
-  			fluids_present = (@cur_contact.is_self? || @person == person) && tracker.fluids_present?(@cur_contact)
-  		else
-  			tracker.track_after(@cur_contact, other_inst)
-  		end
-  	end
-  	fluids_present
-  end
+	def get_fluids(is_before)
+		fluids_present = false
+		@cur_keys.each do |k|
+			person, inst_id_or_alias, is_subject, other_inst = k
+			tracker = @fluid_map[person][inst_id_or_alias]
+			if is_before
+				tracker.track_before(@cur_contact, is_subject)
+				fluids_present = (@cur_contact.is_self? || @person == person) && tracker.fluids_present?(@cur_contact)
+			else
+				tracker.track_after(@cur_contact, other_inst)
+			end
+		end
+		fluids_present
+	end
 
-  def contact_keys
-  	[
-  		[@cur_contact.subject, @cur_possible.subject_instrument_id, true, @instruments[@cur_possible.object_instrument_id]],
-  		[@cur_contact.object, @cur_possible.object_instrument_id, false, @instruments[@cur_possible.subject_instrument_id]]
-  	]
-  end
+	def contact_keys
+		subject_instrument = @instruments[@cur_possible.subject_instrument_id]
+		object_instrument = @instruments[@cur_possible.object_instrument_id]
+		[
+			[@cur_contact.subject, subject_instrument.alias_name, true, object_instrument],
+			[@cur_contact.object, object_instrument.alias_name, false, subject_instrument]
+		]
+	end
 end

--- a/config/locales/models/encounter.yml
+++ b/config/locales/models/encounter.yml
@@ -26,6 +26,7 @@ en:
       toy: toy
       hand: hand
       tongue: tongue
+      fingers: fingers
     barrier:
       none: no barrier
       fresh: with a new barrier

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,17 +30,26 @@ Terms.create(terms: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. D
 ############################
 # Contact Instruments
 ############################
-hand = Contact::Instrument.create(name: :hand)
-external_genitals = Contact::Instrument.create(name: :external_genitals, user_override: :external_name, conditions: {
+hand = Contact::Instrument.new(name: :hand, has_fluids: false)
+hand.upsert
+external_genitals = Contact::Instrument.new(name: :external_genitals, user_override: :external_name, conditions: {
 	can_be_penetrated_by: [:can_penetrate], can_penetrate: [:can_penetrate], can_be_sucked_by_self: [:can_penetrate]
 })
-internal_genitals = Contact::Instrument.create(name: :internal_genitals, user_override: :internal_name, conditions: {
+external_genitals.upsert
+internal_genitals = Contact::Instrument.new(name: :internal_genitals, user_override: :internal_name, conditions: {
 	all: [:internal_name]
 })
-anus = Contact::Instrument.create(name: :anus, user_override: :anus_name)
-mouth = Contact::Instrument.create(name: :mouth)
-toy = Contact::Instrument.create(name: :toy)
-tongue = Contact::Instrument.create(name: :tongue)
+internal_genitals.upsert
+anus = Contact::Instrument.new(name: :anus, user_override: :anus_name)
+anus.upsert
+mouth = Contact::Instrument.new(name: :mouth)
+mouth.upsert
+toy = Contact::Instrument.new(name: :toy, has_fluids: false)
+toy.upsert
+tongue = Contact::Instrument.new(name: :tongue, alias_of: mouth)
+tonuge.upsert
+fingers = Contact::Instrument.new(name: :fingers, has_fluids: false, alias_of: hand)
+fingers.upsert
 
 ############################
 # Possible Contacts
@@ -85,6 +94,9 @@ tongue = Contact::Instrument.create(name: :tongue)
 	end
 end
 
+PossibleContact.where(subject_instrument_id: :hand, contact_type: :penetrated).update_all(subject_instrument_id: :fingers)
+PossibleContact.where(object_instrument_id: :hand, contact_type: :sucked).update_all(object_instrument_id: :fingers)
+
 ############################
 # Diagnoses
 ############################
@@ -118,7 +130,7 @@ HIGH = Diagnosis::TransmissionRisk::HIGH
 
 PossibleContact.find_by(contact_type: :touched, subject_instrument_id: :hand, object_instrument_id: :external_genitals).transmission_risks = [:hpv, :chlamydia, :hsv, :syphillis].map { |t| Diagnosis::TransmissionRisk.new({diagnosis_id: t, risk_to_subject: NEGLIGIBLE, risk_to_object: NEGLIGIBLE}) } +
 [Diagnosis::TransmissionRisk.new({diagnosis_id: :bv, risk_to_subject: NO_RISK, risk_to_object: LOW, risk_to_self: LOW})]
-PossibleContact.find_by(contact_type: :penetrated, subject_instrument_id: :hand, object_instrument_id: :internal_genitals).transmission_risks = [:hpv, :chlamydia, :hsv, :syphillis].map {|t| Diagnosis::TransmissionRisk.new({diagnosis_id: t, risk_to_subject: NEGLIGIBLE, risk_to_object: LOW})} + [Diagnosis::TransmissionRisk.new({diagnosis_id: :bv, risk_to_subject: NO_RISK, risk_to_object: LOW, risk_to_self: LOW})]
+PossibleContact.find_by(contact_type: :penetrated, subject_instrument_id: :fingers, object_instrument_id: :internal_genitals).transmission_risks = [:hpv, :chlamydia, :hsv, :syphillis].map {|t| Diagnosis::TransmissionRisk.new({diagnosis_id: t, risk_to_subject: NEGLIGIBLE, risk_to_object: LOW})} + [Diagnosis::TransmissionRisk.new({diagnosis_id: :bv, risk_to_subject: NO_RISK, risk_to_object: LOW, risk_to_self: LOW})]
 PossibleContact.find_by(contact_type: :fisted, subject_instrument_id: :hand, object_instrument_id: :internal_genitals).transmission_risks = [:hpv, :chlamydia, :hsv, :syphillis].map { |t| Diagnosis::TransmissionRisk.new({diagnosis_id: t, risk_to_subject: LOW, risk_to_object: LOW}) } + [Diagnosis::TransmissionRisk.new({diagnosis_id: :bv, risk_to_subject: LOW, risk_to_object: LOW, risk_to_self: LOW})]
 
 PossibleContact.find_by(contact_type: :touched, subject_instrument_id: :hand, object_instrument_id: :anus).transmission_risks = [:hpv, :chlamydia, :hsv, :syphillis].map { |t| Diagnosis::TransmissionRisk.new({diagnosis_id: t, risk_to_subject: NEGLIGIBLE, risk_to_object: NEGLIGIBLE}) }

--- a/spec/models/contact/instrument_spec.rb
+++ b/spec/models/contact/instrument_spec.rb
@@ -1,84 +1,100 @@
 require 'rails_helper'
 
 RSpec.describe Contact::Instrument, type: :model do
-  context 'custom id' do
-    after :each do
-      cleanup(@inst)
-    end
+	context 'custom id' do
+		after :each do
+			cleanup(@inst)
+		end
 
-    it 'uses the name as the id' do
-      @inst = Contact::Instrument.new(name: :hand);
-      @inst.save
-      expect(@inst.id).to eq @inst.name
-    end
-  end
+		it 'uses the name as the id' do
+			@inst = Contact::Instrument.new(name: :hand);
+			@inst.save
+			expect(@inst.id).to eq @inst.name
+		end
+	end
 
-  context 'methods' do
-  	describe '#get_user_name_for' do
-  		context 'with a user_override' do
-  			it 'returns the user-inputted name for the instrument' do
-	  			user = double({external_name: "ext"})
-	  			inst = build(:contact_instrument, name: "external_genitals", user_override: :external_name)
+	context 'methods' do
+		describe '#get_user_name_for' do
+			context 'with a user_override' do
+				it 'returns the user-inputted name for the instrument' do
+					user = double({external_name: "ext"})
+					inst = build(:contact_instrument, name: "external_genitals", user_override: :external_name)
 
-	  			t_block = I18n.method(:t)
-	  			result = inst.get_user_name_for(user)
-	  			expect(result).to eq user.external_name
-	  		end
-  		end
+					t_block = I18n.method(:t)
+					result = inst.get_user_name_for(user)
+					expect(result).to eq user.external_name
+				end
+			end
 
-  		context 'without user_override' do
-  			it 'defaults to using regular I18n' do
-  				inst_name = "hand"
-  				inst = build(:contact_instrument, name: inst_name)
-  				result = inst.get_user_name_for(double())
+			context 'without user_override' do
+				it 'defaults to using regular I18n' do
+					inst_name = "hand"
+					inst = build(:contact_instrument, name: inst_name)
+					result = inst.get_user_name_for(double())
 
-  				expect(result).to eq I18n.t(inst_name, scope: "contact.instrument")
-  			end
+					expect(result).to eq I18n.t(inst_name, scope: "contact.instrument")
+				end
 
-  			it 'uses the given block to translate' do
-  				inst_name = "hand"
-  				inst = build(:contact_instrument, name: inst_name)
+				it 'uses the given block to translate' do
+					inst_name = "hand"
+					inst = build(:contact_instrument, name: inst_name)
 
-  				prc = Proc.new {|given| given.to_s*2}
-  				result = inst.get_user_name_for(double(), &prc)
+					prc = Proc.new {|given| given.to_s*2}
+					result = inst.get_user_name_for(double(), &prc)
 
-  				expect(result).to eq prc.call(inst_name)
-  			end
-  		end
-  	end
-  end
+					expect(result).to eq prc.call(inst_name)
+				end
+			end
+		end
 
-  context 'class methods' do
-    describe '#hashed_for_partnership' do
-      it 'caches based on user and partner id and update times' do
-        user = build_stubbed(:user_profile)
-        partner = build_stubbed(:profile)
-        allow(Contact::Instrument).to receive(:as_map).and_call_original
-        Contact::Instrument.hashed_for_partnership(user, partner)
-        expect(Contact::Instrument).to have_received(:as_map).once
+		describe '#alias_name' do
+			after do
+				cleanup @inst1, @inst2
+			end
+			it 'returns the name of the instrument this instrument is an alias of' do
+				@inst2 = create(:contact_instrument, name: :hand)
+				@inst1 = create(:contact_instrument, name: :fingers, alias_of: @inst2)
+				expect(@inst1.alias_name).to eq :hand
+			end
 
-        Contact::Instrument.hashed_for_partnership(user, partner)
-        expect(Contact::Instrument).to have_received(:as_map).once
+			it 'returns the name of the instrument if it is not an alias' do
+				@inst1 = create(:contact_instrument, name: :hand)
+				expect(@inst1.alias_name).to eq :hand
+			end
+		end
+	end
 
-        user.updated_at += 1.day
-        Contact::Instrument.hashed_for_partnership(user, partner)
-        expect(Contact::Instrument).to have_received(:as_map).twice
-      end
+	context 'class methods' do
+		describe '#hashed_for_partnership' do
+			it 'caches based on user and partner id and update times' do
+				user = build_stubbed(:user_profile)
+				partner = build_stubbed(:profile)
+				allow(Contact::Instrument).to receive(:as_map).and_call_original
+				Contact::Instrument.hashed_for_partnership(user, partner)
+				expect(Contact::Instrument).to have_received(:as_map).once
 
-      it 'adds the overrides for the partner and user to the serialized hash' do
-        user = build_stubbed(:user_profile)
-        partner = build_stubbed(:profile)
-        inst = build_stubbed(:contact_instrument, name: :external_genitals, user_override: :external_name)
+				Contact::Instrument.hashed_for_partnership(user, partner)
+				expect(Contact::Instrument).to have_received(:as_map).once
 
-        allow(Contact::Instrument).to receive(:as_map) {
-          Hash[inst.id, inst]
-        }
+				user.updated_at += 1.day
+				Contact::Instrument.hashed_for_partnership(user, partner)
+				expect(Contact::Instrument).to have_received(:as_map).twice
+			end
 
-        result = Contact::Instrument.hashed_for_partnership(user, partner)
-        expect(result[inst.id]).to be_a(Hash)
-        expect(result[inst.id][:user_name]).to eq user.external_name
-        expect(result[inst.id][:partner_name]).to eq partner.external_name
-      end
-    end
-  end
+			it 'adds the overrides for the partner and user to the serialized hash' do
+				user = build_stubbed(:user_profile)
+				partner = build_stubbed(:profile)
+				inst = build_stubbed(:contact_instrument, name: :external_genitals, user_override: :external_name)
+
+				allow(Contact::Instrument).to receive(:as_map) {
+					Hash[inst.id, inst]
+				}
+
+				result = Contact::Instrument.hashed_for_partnership(user, partner)
+				expect(result[inst.id]).to be_a(Hash)
+				expect(result[inst.id][:user_name]).to eq user.external_name
+				expect(result[inst.id][:partner_name]).to eq partner.external_name
+			end
+		end
+	end
 end

--- a/spec/models/encounter/fluid_tracker_spec.rb
+++ b/spec/models/encounter/fluid_tracker_spec.rb
@@ -1,156 +1,156 @@
 require 'rails_helper'
 
 RSpec.describe Encounter::FluidTracker, type: :model do
-  describe '#track_before' do
-  	context 'with a clean instrument' do
-  		it 'empties all fluids on the instrument' do
-  			inst = double("Instrument", {can_clean: true})
-  			contact = double("EncounterContact", {barriers: [:clean_subject]})
+	describe '#track_before' do
+		context 'with a clean instrument' do
+			it 'empties all fluids on the instrument' do
+				inst = build_stubbed(:contact_instrument, can_clean: true)
+				contact = double("EncounterContact", {barriers: [:clean_subject]})
 
-  			tracker = Encounter::FluidTracker.new(inst, :user)
-  			tracker.own_on_instrument << :hand
-  			tracker.other_on_instrument << :genitals
-  			expect(tracker.own_on_instrument).to include(:hand)
+				tracker = Encounter::FluidTracker.new(inst, :user)
+				tracker.own_on_instrument << :hand
+				tracker.other_on_instrument << :genitals
+				expect(tracker.own_on_instrument).to include(:hand)
 
-  			tracker.track_before(contact, true)
-  			expect(tracker.own_on_instrument).to be_empty
-  			expect(tracker.other_on_instrument).to be_empty
-  		end
+				tracker.track_before(contact, true)
+				expect(tracker.own_on_instrument).to be_empty
+				expect(tracker.other_on_instrument).to be_empty
+			end
 
-  		it 'leaves any present fluids on the barrier' do
-  			inst = double("Instrument", {can_clean: true})
-  			contact = double("EncounterContact", {barriers: [:clean_subject]})
+			it 'leaves any present fluids on the barrier' do
+				inst = build_stubbed(:contact_instrument, can_clean: true)
+				contact = double("EncounterContact", {barriers: [:clean_subject]})
 
-  			tracker = Encounter::FluidTracker.new(inst, :user)
-  			tracker.other_on_barrier << :genitals
+				tracker = Encounter::FluidTracker.new(inst, :user)
+				tracker.other_on_barrier << :genitals
 
-  			tracker.track_before(contact, true)
-  			expect(tracker.other_on_barrier).to include(:genitals)
-  		end
-  	end
+				tracker.track_before(contact, true)
+				expect(tracker.other_on_barrier).to include(:genitals)
+			end
+		end
 
-  	context 'with a fresh barrier' do
-  		it 'empties all fluids on the barrier' do
-  			inst = double("Instrument", {can_clean: true})
-  			contact = double("EncounterContact", {barriers: [:fresh]})
+		context 'with a fresh barrier' do
+			it 'empties all fluids on the barrier' do
+				inst = build_stubbed(:contact_instrument, can_clean: true)
+				contact = double("EncounterContact", {barriers: [:fresh]})
 
-  			tracker = Encounter::FluidTracker.new(inst, :user)
-  			tracker.own_on_barrier << :hand
-  			expect(tracker.own_on_barrier).to include(:hand)
+				tracker = Encounter::FluidTracker.new(inst, :user)
+				tracker.own_on_barrier << :hand
+				expect(tracker.own_on_barrier).to include(:hand)
 
-  			tracker.track_before(contact, true)
-  			expect(tracker.own_on_barrier).to be_empty
-  		end
+				tracker.track_before(contact, true)
+				expect(tracker.own_on_barrier).to be_empty
+			end
 
-  		it 'leaves any present fluids on the instrument' do
-  			inst = double("Instrument", {can_clean: true})
-  			contact = double("EncounterContact", {barriers: [:fresh]})
+			it 'leaves any present fluids on the instrument' do
+				inst = build_stubbed(:contact_instrument, can_clean: true)
+				contact = double("EncounterContact", {barriers: [:fresh]})
 
-  			tracker = Encounter::FluidTracker.new(inst, :user)
-  			tracker.other_on_instrument << :genitals
+				tracker = Encounter::FluidTracker.new(inst, :user)
+				tracker.other_on_instrument << :genitals
 
-  			tracker.track_before(contact, true)
-  			expect(tracker.other_on_instrument).to include(:genitals)
-  		end
-  	end
-  end
+				tracker.track_before(contact, true)
+				expect(tracker.other_on_instrument).to include(:genitals)
+			end
+		end
+	end
 
-  describe '#track_after' do
-  	context 'with an other instrument with no fluids' do
-  		it 'does nothing' do
-  			inst = double("Instrument", {has_fluids: false})
-  			contact = double("EncounterContact")
+	describe '#track_after' do
+		context 'with an other instrument with no fluids' do
+			it 'does nothing' do
+				inst = build_stubbed(:contact_instrument, has_fluids: false)
+				contact = double("EncounterContact")
 
-  			tracker = Encounter::FluidTracker.new(inst, :user)
-  			tracker.track_after(contact, inst)
+				tracker = Encounter::FluidTracker.new(inst, :user)
+				tracker.track_after(contact, inst)
 
-  			expect(tracker.own_on_barrier).to be_empty
-  			expect(tracker.other_on_barrier).to be_empty
-  			expect(tracker.own_on_instrument).to be_empty
-  			expect(tracker.other_on_instrument).to be_empty
-  		end
-  	end
+				expect(tracker.own_on_barrier).to be_empty
+				expect(tracker.other_on_barrier).to be_empty
+				expect(tracker.own_on_instrument).to be_empty
+				expect(tracker.other_on_instrument).to be_empty
+			end
+		end
 
-  	context 'with a barrier' do
-  		context 'in a self-contact' do
-  			it 'adds the other instrument id to @own_on_barrier' do
-  				inst = double("Instrument", {has_fluids: true, _id: :genitals})
-  				contact = double("EncounterContact", {has_barrier?: true, is_self?: true})
+		context 'with a barrier' do
+			context 'in a self-contact' do
+				it 'adds the other instrument alias name to @own_on_barrier' do
+					inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals, alias_of_id: :external_genitals)
+					contact = double("EncounterContact", {has_barrier?: true, is_self?: true})
 
-  				tracker = Encounter::FluidTracker.new(inst, :user)
-  				tracker.track_after(contact, inst)
+					tracker = Encounter::FluidTracker.new(inst, :user)
+					tracker.track_after(contact, inst)
 
-  				expect(tracker.own_on_barrier).to include(inst._id)
-  			end
-  		end
+					expect(tracker.own_on_barrier).to include(inst.alias_name)
+				end
+			end
 
-  		context 'in a partner contact' do
-  			it 'adds the other instrument id to @other_on_barrier' do
-  				inst = double("Instrument", {has_fluids: true, _id: :genitals})
-  				contact = double("EncounterContact", {has_barrier?: true, is_self?: false})
+			context 'in a partner contact' do
+				it 'adds the other instrument id to @other_on_barrier' do
+					inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals)
+					contact = double("EncounterContact", {has_barrier?: true, is_self?: false})
 
-  				tracker = Encounter::FluidTracker.new(inst, :user)
-  				tracker.track_after(contact, inst)
+					tracker = Encounter::FluidTracker.new(inst, :user)
+					tracker.track_after(contact, inst)
 
-  				expect(tracker.other_on_barrier).to include(inst._id)
-  			end
-  		end
-  	end
+					expect(tracker.other_on_barrier).to include(inst._id)
+				end
+			end
+		end
 
-  	context 'without a barrier' do
-  		context 'in a self-contact' do
-  			it 'adds the other instrument id to @own_on_instrument' do
-  				inst = double("Instrument", {has_fluids: true, _id: :genitals})
-  				contact = double("EncounterContact", {has_barrier?: false, is_self?: true})
+		context 'without a barrier' do
+			context 'in a self-contact' do
+				it 'adds the other instrument id to @own_on_instrument' do
+					inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals)
+					contact = double("EncounterContact", {has_barrier?: false, is_self?: true})
 
-  				tracker = Encounter::FluidTracker.new(inst, :user)
-  				tracker.track_after(contact, inst)
+					tracker = Encounter::FluidTracker.new(inst, :user)
+					tracker.track_after(contact, inst)
 
-  				expect(tracker.own_on_instrument).to include(inst._id)
-  			end
-  		end
+					expect(tracker.own_on_instrument).to include(inst._id)
+				end
+			end
 
-  		context 'in a partner contact' do
-  			it 'adds the other instrument id to @other_on_instrument' do
-  				inst = double("Instrument", {has_fluids: true, _id: :genitals})
-  				contact = double("EncounterContact", {has_barrier?: false, is_self?: false})
+			context 'in a partner contact' do
+				it 'adds the other instrument id to @other_on_instrument' do
+					inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals)
+					contact = double("EncounterContact", {has_barrier?: false, is_self?: false})
 
-  				tracker = Encounter::FluidTracker.new(inst, :user)
-  				tracker.track_after(contact, inst)
+					tracker = Encounter::FluidTracker.new(inst, :user)
+					tracker.track_after(contact, inst)
 
-  				expect(tracker.other_on_instrument).to include(inst._id)
-  			end
-  		end
-  	end
-  end
+					expect(tracker.other_on_instrument).to include(inst._id)
+				end
+			end
+		end
+	end
 
-  describe '#fluids_present?' do
-  	context 'a self contact' do
-  		it 'returns whether the fluids from the other person are on the instrument' do
-  			inst = double("Instrument", {has_fluids: true, _id: :genitals})
-  			contact1 = double("EncounterContact", {has_barrier?: true, is_self?: true})
-  			contact2 = double("EncounterContact", {has_barrier?: false, is_self?: true})
+	describe '#fluids_present?' do
+		context 'a self contact' do
+			it 'returns whether the fluids from the other person are on the instrument' do
+				inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals)
+				contact1 = double("EncounterContact", {has_barrier?: true, is_self?: true})
+				contact2 = double("EncounterContact", {has_barrier?: false, is_self?: true})
 
-  			tracker = Encounter::FluidTracker.new(inst, :partner)
-  			tracker.other_on_barrier << :anus
+				tracker = Encounter::FluidTracker.new(inst, :partner)
+				tracker.other_on_barrier << :anus
 
-  			expect(tracker.fluids_present?(contact1)).to be true
-  			expect(tracker.fluids_present?(contact2)).to be false
-  		end
-  	end
+				expect(tracker.fluids_present?(contact1)).to be true
+				expect(tracker.fluids_present?(contact2)).to be false
+			end
+		end
 
-  	context 'a partner contact' do
-  		it 'returns whether fluids from the person the instrument belongs to are on the instrument' do
-  			inst = double("Instrument", {has_fluids: true, _id: :genitals})
-  			contact1 = double("EncounterContact", {has_barrier?: true, is_self?: false})
-  			contact2 = double("EncounterContact", {has_barrier?: false, is_self?: false})
+		context 'a partner contact' do
+			it 'returns whether fluids from the person the instrument belongs to are on the instrument' do
+				inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals)
+				contact1 = double("EncounterContact", {has_barrier?: true, is_self?: false})
+				contact2 = double("EncounterContact", {has_barrier?: false, is_self?: false})
 
-  			tracker = Encounter::FluidTracker.new(inst, :partner)
-  			tracker.own_on_barrier << :anus
+				tracker = Encounter::FluidTracker.new(inst, :partner)
+				tracker.own_on_barrier << :anus
 
-  			expect(tracker.fluids_present?(contact1)).to be true
-  			expect(tracker.fluids_present?(contact2)).to be false
-  		end
-  	end
-  end
+				expect(tracker.fluids_present?(contact1)).to be true
+				expect(tracker.fluids_present?(contact2)).to be false
+			end
+		end
+	end
 end

--- a/spec/models/encounter/risk_calculator_spec.rb
+++ b/spec/models/encounter/risk_calculator_spec.rb
@@ -1,191 +1,209 @@
 require 'rails_helper'
 
 RSpec.describe Encounter::RiskCalculator, type: :model do
-  before :each do
-  	allow(Diagnosis).to receive(:as_map) {Hash.new {|hsh, key| hsh[key] = build_stubbed(:diagnosis, {name: key})}}
-  	allow(PossibleContact).to receive(:as_map) {Hash.new { |hsh, key| hsh[key] = build_stubbed(:possible_contact, {subject_instrument_id: :external_genitals, object_instrument_id: :internal_genitals, _id: key}) }}
-  	allow(Contact::Instrument).to receive(:as_map) {Hash.new { |hsh, key| hsh[key] = build_stubbed(:contact_instrument, {name: key}) }}
-  	allow(Diagnosis::TransmissionRisk).to receive(:grouped_by) {Hash.new { |hsh, key| hsh[key] = [build_stubbed(:diagnosis_transmission_risk, {possible_contact_id: key})] }}
-  end
+	before :each do
+		allow(Diagnosis).to receive(:as_map) {Hash.new {|hsh, key| hsh[key] = build_stubbed(:diagnosis, {name: key})}}
+		allow(PossibleContact).to receive(:as_map) {Hash.new { |hsh, key| hsh[key] = build_stubbed(:possible_contact, {subject_instrument_id: :external_genitals, object_instrument_id: :internal_genitals, _id: key}) }}
+		allow(Contact::Instrument).to receive(:as_map) {Hash.new { |hsh, key| hsh[key] = build_stubbed(:contact_instrument, {name: key}) }}
+		allow(Diagnosis::TransmissionRisk).to receive(:grouped_by) {Hash.new { |hsh, key| hsh[key] = [build_stubbed(:diagnosis_transmission_risk, {possible_contact_id: key})] }}
+	end
 
-  it 'creates a map showing the highest transmission risk of the encounter for each diagnosis' do
-  	calc = Encounter::RiskCalculator.new(Encounter.new)
-  	risks = calc.instance_variable_get(:@risks)
+	it 'creates a map showing the highest transmission risk of the encounter for each diagnosis' do
+		calc = Encounter::RiskCalculator.new(Encounter.new)
+		risks = calc.instance_variable_get(:@risks)
 
-  	contact1 = build_stubbed(:encounter_contact, {possible_contact_id: "contact1"})
-  	calc.track_contact(contact1)
-  	risk1 = risks[contact1.possible_contact_id][0]
+		contact1 = build_stubbed(:encounter_contact, {possible_contact_id: "contact1"})
+		calc.track_contact(contact1)
+		risk1 = risks[contact1.possible_contact_id][0]
 
-  	expect(calc.risk_map[risk1.diagnosis_id]).to eq risk1.risk_to_subject
+		expect(calc.risk_map[risk1.diagnosis_id]).to eq risk1.risk_to_subject
 
-  	contact2 = build_stubbed(:encounter_contact, {possible_contact_id: "contact2"})
-  	calc.track_contact(contact2)
-  	risk2 = risks[contact2.possible_contact_id][0]
+		contact2 = build_stubbed(:encounter_contact, {possible_contact_id: "contact2"})
+		calc.track_contact(contact2)
+		risk2 = risks[contact2.possible_contact_id][0]
 
-  	contact3 = build_stubbed(:encounter_contact, {possible_contact_id: "contact3"})
-  	calc.track_contact(contact3)
-  	risk3 = risks[contact3.possible_contact_id][0]
+		contact3 = build_stubbed(:encounter_contact, {possible_contact_id: "contact3"})
+		calc.track_contact(contact3)
+		risk3 = risks[contact3.possible_contact_id][0]
 
-  	expected = [risk1.risk_to_subject, risk2.risk_to_subject, risk3.risk_to_subject].max
-  	expect(calc.risk_map[risk1.diagnosis_id]).to eq expected
-  end
+		expected = [risk1.risk_to_subject, risk2.risk_to_subject, risk3.risk_to_subject].max
+		expect(calc.risk_map[risk1.diagnosis_id]).to eq expected
+	end
 
-  describe '#track_contact' do
-    describe 'with an effective barrier' do
-      it 'returns negligible risk' do
-        contact1 = build_stubbed(:encounter_contact, {possible_contact_id: "contact1", barriers: ["fresh"]})
-        encounter = build(:encounter)
-        encounter.contacts = [contact1]
-        calc = Encounter::RiskCalculator.new(encounter)
+	describe '#track_contact' do
+		describe 'with an effective barrier' do
+			it 'returns negligible risk' do
+				contact1 = build_stubbed(:encounter_contact, {possible_contact_id: "contact1", barriers: ["fresh"]})
+				encounter = build(:encounter)
+				encounter.contacts = [contact1]
+				calc = Encounter::RiskCalculator.new(encounter)
 
-        calc.instance_variable_get(:@risks)["contact1"][0].risk_to_subject = Diagnosis::TransmissionRisk::HIGH
+				calc.instance_variable_get(:@risks)["contact1"][0].risk_to_subject = Diagnosis::TransmissionRisk::HIGH
 
-        calc.track_contact(contact1)
+				calc.track_contact(contact1)
 
-        expect(contact1.risks[:hpv]).to eq Diagnosis::TransmissionRisk::NEGLIGIBLE
-      end
-    end
-  end
+				expect(contact1.risks[:hpv]).to eq Diagnosis::TransmissionRisk::NEGLIGIBLE
+			end
+		end
+	end
 
-  describe '#track' do
-    before :each do
-      @contact1 = build_stubbed(:encounter_contact, {possible_contact_id: "contact1"})
-      @contact2 = build_stubbed(:encounter_contact, {possible_contact_id: "contact2"})
-      @contact3 = build_stubbed(:encounter_contact, {possible_contact_id: "contact3", barriers: ["fresh"]})
+	describe '#track' do
+		before :each do
+			@contact1 = build_stubbed(:encounter_contact, {possible_contact_id: "contact1"})
+			@contact2 = build_stubbed(:encounter_contact, {possible_contact_id: "contact2"})
+			@contact3 = build_stubbed(:encounter_contact, {possible_contact_id: "contact3", barriers: ["fresh"]})
 
-      @ship = build_stubbed(:partnership)
-      @encounter = build_stubbed(:encounter)
-      @ship.encounters = [@encounter]
-      @encounter.contacts = [@contact1, @contact2, @contact3]
-      @calc = Encounter::RiskCalculator.new(@encounter)
-      @calc.instance_variable_get(:@diagnoses)[:hpv]
-    end
+			@ship = build_stubbed(:partnership)
+			@encounter = build_stubbed(:encounter)
+			@ship.encounters = [@encounter]
+			@encounter.contacts = [@contact1, @contact2, @contact3]
+			@calc = Encounter::RiskCalculator.new(@encounter)
+			@calc.instance_variable_get(:@diagnoses)[:hpv]
+		end
 
-    it 'tracks all contacts in an encounter' do
-      allow(@ship).to receive(:risk_mitigator) {0}
-      @calc.track
+		it 'tracks all contacts in an encounter' do
+			allow(@ship).to receive(:risk_mitigator) {0}
+			@calc.track
 
-      risks = @calc.instance_variable_get(:@risks)
+			risks = @calc.instance_variable_get(:@risks)
 
-      risk1 = risks[@contact1.possible_contact_id][0]
-      risk2 = risks[@contact2.possible_contact_id][0]
-      risk3 = risks[@contact3.possible_contact_id][0]
+			risk1 = risks[@contact1.possible_contact_id][0]
+			risk2 = risks[@contact2.possible_contact_id][0]
+			risk3 = risks[@contact3.possible_contact_id][0]
 
-      expected = [risk1.risk_to_subject, risk2.risk_to_subject].max
-      expect(@calc.risk_map[risk1.diagnosis_id]).to eq expected
-      expect(@contact3.risks[:hpv]).to eq Diagnosis::TransmissionRisk::NEGLIGIBLE
-    end
+			expected = [risk1.risk_to_subject, risk2.risk_to_subject].max
+			expect(@calc.risk_map[risk1.diagnosis_id]).to eq expected
+			expect(@contact3.risks[:hpv]).to eq Diagnosis::TransmissionRisk::NEGLIGIBLE
+		end
 
-    context 'risk mitigation' do
-      context 'when calculating risk-to-user' do
-        it 'mitigates risks by the partnership risk mitgator' do
-          mitigation = 1
-          allow(@encounter.partnership).to receive(:risk_mitigator) {mitigation}
-          risks = @calc.instance_variable_get(:@risks)
-          risk1 = risks[@contact1.possible_contact_id][0]
-          risk1.risk_to_subject = 3
+		context 'risk mitigation' do
+			context 'when calculating risk-to-user' do
+				it 'mitigates risks by the partnership risk mitgator' do
+					mitigation = 1
+					allow(@encounter.partnership).to receive(:risk_mitigator) {mitigation}
+					risks = @calc.instance_variable_get(:@risks)
+					risk1 = risks[@contact1.possible_contact_id][0]
+					risk1.risk_to_subject = 3
 
-          @calc.track
-          expect(@contact1.risks[risk1.diagnosis_id]).to eq(risk1.risk_to_subject - mitigation)
-        end
+					@calc.track
+					expect(@contact1.risks[risk1.diagnosis_id]).to eq(risk1.risk_to_subject - mitigation)
+				end
 
-        it 'does not mitigate below negligible' do
-          mitigation = 1
-          allow(@encounter.partnership).to receive(:risk_mitigator) {mitigation}
-          risks = @calc.instance_variable_get(:@risks)
-          risk1 = risks[@contact1.possible_contact_id][0]
-          risk1.risk_to_subject = Diagnosis::TransmissionRisk::NEGLIGIBLE
+				it 'does not mitigate below negligible' do
+					mitigation = 1
+					allow(@encounter.partnership).to receive(:risk_mitigator) {mitigation}
+					risks = @calc.instance_variable_get(:@risks)
+					risk1 = risks[@contact1.possible_contact_id][0]
+					risk1.risk_to_subject = Diagnosis::TransmissionRisk::NEGLIGIBLE
 
-          @calc.track
-          expect(@contact1.risks[risk1.diagnosis_id]).to eq(Diagnosis::TransmissionRisk::NEGLIGIBLE)
-        end
-      end
+					@calc.track
+					expect(@contact1.risks[risk1.diagnosis_id]).to eq(Diagnosis::TransmissionRisk::NEGLIGIBLE)
+				end
+			end
 
-      context 'when calculating risk-to-partner' do
-        it 'mitigates risk by the user risk mitgator' do
-          mitigation = 1
-          allow(@encounter.partnership).to receive(:user_profile) {double("UserProfile", risk_mitigator: mitigation)}
-          risks = @calc.instance_variable_get(:@risks)
-          risk1 = risks[@contact1.possible_contact_id][0]
-          risk1.risk_to_object = 3
+			context 'when calculating risk-to-partner' do
+				it 'mitigates risk by the user risk mitgator' do
+					mitigation = 1
+					allow(@encounter.partnership).to receive(:user_profile) {double("UserProfile", risk_mitigator: mitigation)}
+					risks = @calc.instance_variable_get(:@risks)
+					risk1 = risks[@contact1.possible_contact_id][0]
+					risk1.risk_to_object = 3
 
-          @calc.track(:partner)
-          expect(@contact1.risks[risk1.diagnosis_id]).to eq(risk1.risk_to_object - mitigation)
-        end
-      end
+					@calc.track(:partner)
+					expect(@contact1.risks[risk1.diagnosis_id]).to eq(risk1.risk_to_object - mitigation)
+				end
+			end
 
-        it 'does not mitigate below no risk' do
-          mitigation = 2
-          allow(@encounter.partnership).to receive(:user_profile) {double("UserProfile", risk_mitigator: mitigation)}
-          risks = @calc.instance_variable_get(:@risks)
-          risk1 = risks[@contact1.possible_contact_id][0]
-          risk1.risk_to_object = Diagnosis::TransmissionRisk::NO_RISK + 1
+				it 'does not mitigate below no risk' do
+					mitigation = 2
+					allow(@encounter.partnership).to receive(:user_profile) {double("UserProfile", risk_mitigator: mitigation)}
+					risks = @calc.instance_variable_get(:@risks)
+					risk1 = risks[@contact1.possible_contact_id][0]
+					risk1.risk_to_object = Diagnosis::TransmissionRisk::NO_RISK + 1
 
-          @calc.track(:partner)
-          expect(@contact1.risks[risk1.diagnosis_id]).to eq(Diagnosis::TransmissionRisk::NO_RISK)
-        end
-    end
-  end
+					@calc.track(:partner)
+					expect(@contact1.risks[risk1.diagnosis_id]).to eq(Diagnosis::TransmissionRisk::NO_RISK)
+				end
+		end
+	end
 
-  describe '#schedule' do
-    before :each do
-      @encounter = build_stubbed(:encounter)
-    end
+	describe '#schedule' do
+		before :each do
+			@encounter = build_stubbed(:encounter)
+		end
 
-    it 'returns a hash with best test dates as keys and arrays of diagnoses as values' do
-      calc = Encounter::RiskCalculator.new(@encounter)
-      calc.instance_variable_set :@risk_map, {
-        hpv: Diagnosis::TransmissionRisk::MODERATE,
-        hsv: Diagnosis::TransmissionRisk::HIGH
-      }
+		it 'returns a hash with best test dates as keys and arrays of diagnoses as values' do
+			calc = Encounter::RiskCalculator.new(@encounter)
+			calc.instance_variable_set :@risk_map, {
+				hpv: Diagnosis::TransmissionRisk::MODERATE,
+				hsv: Diagnosis::TransmissionRisk::HIGH
+			}
 
-      result = calc.schedule
-      diags = calc.instance_variable_get(:@diagnoses)
-      expected_hpv_best = diags[:hpv].best_test
-      expected_hiv_best = diags[:hpv].best_test
+			result = calc.schedule
+			diags = calc.instance_variable_get(:@diagnoses)
+			expected_hpv_best = diags[:hpv].best_test
+			expected_hiv_best = diags[:hpv].best_test
 
-      expect(expected_hiv_best).to eq expected_hpv_best
-      expected_date = @encounter.took_place + expected_hpv_best.weeks
-      expect(result).to have_key expected_date
-      expect(result[expected_date].length).to be 2
-      expect(result[expected_date]).to include(:hpv)
-      expect(result[expected_date]).to include(:hsv)
-    end
+			expect(expected_hiv_best).to eq expected_hpv_best
+			expected_date = @encounter.took_place + expected_hpv_best.weeks
+			expect(result).to have_key expected_date
+			expect(result[expected_date].length).to be 2
+			expect(result[expected_date]).to include(:hpv)
+			expect(result[expected_date]).to include(:hsv)
+		end
 
-    it 'keys LOW and NEGLIGIBLE risk diagnoses with :routine' do
-      calc = Encounter::RiskCalculator.new(@encounter)
-      calc.instance_variable_set :@risk_map, {
-        hpv: Diagnosis::TransmissionRisk::NEGLIGIBLE,
-        hsv: Diagnosis::TransmissionRisk::LOW,
-        hiv: Diagnosis::TransmissionRisk::MODERATE
-      }
+		it 'keys LOW and NEGLIGIBLE risk diagnoses with :routine' do
+			calc = Encounter::RiskCalculator.new(@encounter)
+			calc.instance_variable_set :@risk_map, {
+				hpv: Diagnosis::TransmissionRisk::NEGLIGIBLE,
+				hsv: Diagnosis::TransmissionRisk::LOW,
+				hiv: Diagnosis::TransmissionRisk::MODERATE
+			}
 
-      result = calc.schedule
-      diags = calc.instance_variable_get(:@diagnoses)
-      best_hiv = @encounter.took_place + diags[:hiv].best_test.weeks
+			result = calc.schedule
+			diags = calc.instance_variable_get(:@diagnoses)
+			best_hiv = @encounter.took_place + diags[:hiv].best_test.weeks
 
-      expect(result[best_hiv]).to eq [:hiv]
-      expect(result[:routine]).to include(:hpv)
-      expect(result[:routine]).to include(:hsv)
-    end
+			expect(result[best_hiv]).to eq [:hiv]
+			expect(result[:routine]).to include(:hpv)
+			expect(result[:routine]).to include(:hsv)
+		end
 
-    it 'keys LOW and NEGLIGIBLE risk diagnoses with their best dates if passed force = true' do
-      calc = Encounter::RiskCalculator.new(@encounter)
-      calc.instance_variable_set :@risk_map, {
-        hpv: Diagnosis::TransmissionRisk::NEGLIGIBLE,
-        hsv: Diagnosis::TransmissionRisk::LOW,
-        hiv: Diagnosis::TransmissionRisk::MODERATE
-      }
-      result = calc.schedule(true)
-      diags = calc.instance_variable_get(:@diagnoses)
-      best_hiv = @encounter.took_place + diags[:hiv].best_test.weeks
-      best_hsv = @encounter.took_place + diags[:hsv].best_test.weeks
-      best_hpv = @encounter.took_place + diags[:hpv].best_test.weeks
+		it 'keys LOW and NEGLIGIBLE risk diagnoses with their best dates if passed force = true' do
+			calc = Encounter::RiskCalculator.new(@encounter)
+			calc.instance_variable_set :@risk_map, {
+				hpv: Diagnosis::TransmissionRisk::NEGLIGIBLE,
+				hsv: Diagnosis::TransmissionRisk::LOW,
+				hiv: Diagnosis::TransmissionRisk::MODERATE
+			}
+			result = calc.schedule(true)
+			diags = calc.instance_variable_get(:@diagnoses)
+			best_hiv = @encounter.took_place + diags[:hiv].best_test.weeks
+			best_hsv = @encounter.took_place + diags[:hsv].best_test.weeks
+			best_hpv = @encounter.took_place + diags[:hpv].best_test.weeks
 
-      expect(result).to_not have_key :routine
-      expect(result[best_hiv]).to include(:hiv)
-      expect(result[best_hpv]).to include(:hpv)
-      expect(result[best_hsv]).to include(:hsv)
-    end
-  end
+			expect(result).to_not have_key :routine
+			expect(result[best_hiv]).to include(:hiv)
+			expect(result[best_hpv]).to include(:hpv)
+			expect(result[best_hsv]).to include(:hsv)
+		end
+	end
+
+	describe '#contact_keys' do
+		it 'uses the alias name rather than the name of the instruments as the second key' do
+			calc = Encounter::RiskCalculator.new(Encounter.new)
+			instruments = calc.instance_variable_get(:@instruments)
+			instruments[:fingers].alias_of_id = :hand
+
+			cur_possible = build_stubbed(:possible_contact, {subject_instrument_id: :fingers, object_instrument_id: :internal_genitals, _id: "pos1"})
+			cur_contact = build_stubbed(:encounter_contact, possible_contact_id: "pos1")
+			calc.instance_variable_set(:@cur_possible, cur_possible)
+			calc.instance_variable_set(:@cur_contact, cur_contact)
+
+			result = calc.contact_keys
+
+			expect(result[0][1]).to eq :hand
+			expect(result[1][1]).to eq :internal_genitals
+		end
+	end
 end


### PR DESCRIPTION
Allow different ways of referring to body parts when they're doing different actions to still correspond to the same parts when tracking fluids