### PR TITLE
Smarter barrier tracking across an encounter

### DIFF
--- a/app/javascript/components/form/encounter/EncounterContactField.vue
+++ b/app/javascript/components/form/encounter/EncounterContactField.vue
@@ -158,7 +158,7 @@ export default {
 		});
 
 		// send the tracker factory to the parent
-		this.$emit('start-tracking', (list) => new EncounterBarrierTracker(list, this.possibles, this.instruments));
+		this.$emit('start-tracking', (list) => new EncounterBarrierTracker(list, this.possibles, this.instruments, this.partner, this.user));
 	},
 };
 </script>

--- a/app/javascript/modules/encounterBarrierTracker.js
+++ b/app/javascript/modules/encounterBarrierTracker.js
@@ -60,13 +60,12 @@ export default class EncounterBarrierTracker {
 
 			// get the possible contact
 			let possibleContact = that.possibleContacts[c.possible_contact_id];
-			// paths to set for this contact
-			let paths = [`${c.subject}.${possibleContact.subject_instrument_id}`, `${c.object}.${possibleContact.object_instrument_id}`];
 			// track whether it is the first barrier on both instruments
 			let isFirst = true;
 			// set the value of each path if it is not already set
-			this.checkInstrumentBarriers(c, possibleContact, (barrier, i) => {
-				const path = `${paths[i]}.${barrier.type}`;
+			this.checkInstrumentBarriers(c, possibleContact, (barrier, instrument, i) => {
+				const person = c[ACTORS[i]];
+				const path = `${person}.${instrument.alias_name}.${barrier.type}`;
 				if (Object.getAtPath(that.barriers, path) === undefined) {
 					// isFirst.push(barrier.type);
 					// the value is the first contact position that has a fresh barrier on this instrument for this person
@@ -103,11 +102,13 @@ export default class EncounterBarrierTracker {
 				}
 
 				const otherInstActor = ACTORS[i == 0 ? 1 : 0];
-				if(barrier.with_insts && barrier.with_insts.indexOf(possibleContact[`${otherInstActor}_instrument_id`]) == -1) {
+				const otherInstID = possibleContact[`${otherInstActor}_instrument_id`];
+				const otherInstAlias = this.instruments[otherInstID].alias_name;
+				if(barrier.with_insts && barrier.with_insts.indexOf(otherInstAlias) == -1) {
 					return;
 				}
 
-				callback && callback(barrier, i);
+				callback && callback(barrier, instrument, i);
 			});
 		}
 	}
@@ -126,12 +127,11 @@ export default class EncounterBarrierTracker {
 		let possibleContact = this.possibleContacts[contact.possible_contact_id];
 		// get the positions of the barriers
 		let has = false;
-		this.checkInstrumentBarriers(contact, possibleContact, (barrier, i) => {
+		this.checkInstrumentBarriers(contact, possibleContact, (barrier, instrument, i) => {
 			let actor = ACTORS[i];
 			let person = contact[actor];
-			let instrumentID = possibleContact[`${actor}_instrument_id`];
 
-			let instrumentBarriers = this.barriers[person][instrumentID];
+			let instrumentBarriers = this.barriers[person][instrument.alias_name];
 			if (instrumentBarriers && instrumentBarriers[barrier.type] < contact.position) {
 				has = true;
 			}

--- a/app/javascript/modules/encounterBarrierTracker.js
+++ b/app/javascript/modules/encounterBarrierTracker.js
@@ -67,8 +67,8 @@ export default class EncounterBarrierTracker {
 				const person = c[ACTORS[i]];
 				const path = `${person}.${instrument.alias_name}.${barrier.type}`;
 				if (Object.getAtPath(that.barriers, path) === undefined) {
-					// isFirst.push(barrier.type);
-					// the value is the first contact position that has a fresh barrier on this instrument for this person
+					// the value is the first contact position that has a
+					// fresh barrier of this type on this instrument for this person
 					Object.setAtPath(that.barriers, path, c.position);
 				} else {
 					isFirst = false;
@@ -78,6 +78,7 @@ export default class EncounterBarrierTracker {
 			// if it's now first, but it used to say it reused a barrier, make it have a new barrier
 			let oldIndex = c.barriers.indexOf('old');
 			if (oldIndex >= 0 && isFirst) {
+				// splice so that vue knows a change was made to the array
 				c.barriers.splice(oldIndex, 1, 'fresh');
 			}
 		});

--- a/app/javascript/tests/modules/encounterBarrierTracker.test.js
+++ b/app/javascript/tests/modules/encounterBarrierTracker.test.js
@@ -14,15 +14,20 @@ const defaultPossibles = {
 
 const defaultInstruments = {
 	hand: {
-		subject_barriers: [{type: 'glove'}]
+		subject_barriers: [{type: 'glove'}],
+		alias_name: 'hand'
 	},
 	mouth: {
-		subject_barriers: [{type: 'dam'}]
+		subject_barriers: [{type: 'dam'}],
+		alias_name: 'mouth'
 	},
 	anus: {
-		object_barriers: [{type: 'condom'}]
+		object_barriers: [{type: 'condom'}],
+		alias_name: 'anus'
 	},
-	external_genitals: {}
+	external_genitals: {
+		alias_name: 'external_genitals'
+	}
 };
 
 describe('Encounter Barrier Tracker class', () => {

--- a/app/javascript/tests/modules/encounterBarrierTracker.test.js
+++ b/app/javascript/tests/modules/encounterBarrierTracker.test.js
@@ -104,7 +104,69 @@ describe('Encounter Barrier Tracker class', () => {
 
 			expect(tracker.contacts[0].barriers).toEqual(['fresh']);
 		});
+
+		it('associates a barrier with the object instrument if the instrument has object_barriers', () => {
+			const tracker = new EncounterBarrierTracker([{
+				possible_contact_id: 'pos2',
+				barriers: ['fresh'],
+				subject: 'user',
+				object: 'partner',
+				position: 1
+			}], defaultPossibles, {
+				hand: {
+					alias_name: 'hand'
+				},
+				anus: {
+					alias_name: 'anus',
+					object_barriers: [{type: 'condom'}]
+				}
+			}, {}, {});
+			expect(tracker.barriers.partner.anus).toEqual({condom: 1});
+		});
+
+		it('does not associate a barrier with an instrument that does not pass the conditions for the person using it', () => {
+			const tracker = new EncounterBarrierTracker([{
+				possible_contact_id: 'pos2',
+				barriers: ['fresh'],
+				subject: 'user',
+				object: 'partner',
+				position: 1
+			}], defaultPossibles, {
+				hand: {
+					alias_name: 'hand',
+					subject_barriers: [{type: 'glove', conditions: ['can_penetrate']}]
+				},
+				anus: {
+					alias_name: 'anus',
+					object_barriers: [{type: 'condom'}]
+				}
+			}, {}, {});
+			expect(tracker.barriers.partner.anus).toEqual({condom: 1});
+			expect(tracker.barriers.user.hand).toBeUndefined();
+		});
+
+		it('does not associate a barrier with an instrument that requires specific other instruments if none of those are present', () => {
+			const tracker = new EncounterBarrierTracker([{
+				possible_contact_id: 'pos2',
+				barriers: ['fresh'],
+				subject: 'user',
+				object: 'partner',
+				position: 1
+			}], defaultPossibles, {
+				hand: {
+					alias_name: 'hand',
+					subject_barriers: [{type: 'glove', with_insts: ['mouth']}]
+				},
+				anus: {
+					alias_name: 'anus',
+					object_barriers: [{type: 'condom'}]
+				}
+			}, {}, {});
+			expect(tracker.barriers.partner.anus).toEqual({condom: 1});
+			expect(tracker.barriers.user.hand).toBeUndefined();
+		});
 	});
+
 
 	describe('has_barrier', () => {
 		it('returns false if the given contact does not have a possible contact id', () => {

--- a/app/models/contact/instrument.rb
+++ b/app/models/contact/instrument.rb
@@ -40,6 +40,7 @@ class Contact::Instrument
 				# (methods: Contact::ContactType.inst_methods)
 				hsh[:user_name] = i.get_user_name_for(user)
 				hsh[:partner_name] = i.get_user_name_for(partner)
+				hsh[:alias_name] = i.alias_name
 				[i.id, hsh]
 			end]
 		end

--- a/app/models/contact/instrument.rb
+++ b/app/models/contact/instrument.rb
@@ -8,6 +8,9 @@ class Contact::Instrument
 	field :can_clean, type: Boolean, default: false
 	field :has_fluids, type: Boolean, default: true
 	field :conditions, type: Hash
+	field :subject_barriers, type: Array
+	field :object_barriers, type: Array
+
 	index({name: 1}, {unique: true})
 
 	has_many :as_subject, class_name: 'PossibleContact', inverse_of: :subject_instrument, dependent: :restrict_with_error

--- a/app/models/encounter/fluid_tracker.rb
+++ b/app/models/encounter/fluid_tracker.rb
@@ -20,8 +20,12 @@ class Encounter::FluidTracker
 	end
  end
 
- def track_after(contact, other_inst)
+ def track_after(contact, other_inst, is_subject)
 	return unless other_inst.has_fluids
+
+	inst_barriers = is_subject ? @inst.subject_barriers : @inst.object_barriers
+	return if contact.has_barrier? && inst_barriers.blank?
+
 	lst = get_list(contact, contact.is_self?)
 	lst << other_inst.alias_name
  end

--- a/app/models/encounter/fluid_tracker.rb
+++ b/app/models/encounter/fluid_tracker.rb
@@ -20,9 +20,12 @@ class Encounter::FluidTracker
 	end
  end
 
+ # track where fluids are at the end of the given contact
  def track_after(contact, other_inst, is_subject)
+	# if the other instrument has no fluids, then nothing has changed
 	return unless other_inst.has_fluids
 
+	# if this instrument has no barriers that can associate with it but the contact has barriers, then nothing has changed
 	inst_barriers = is_subject ? @inst.subject_barriers : @inst.object_barriers
 	return if contact.has_barrier? && inst_barriers.blank?
 

--- a/app/models/encounter/risk_calculator.rb
+++ b/app/models/encounter/risk_calculator.rb
@@ -126,7 +126,7 @@ class Encounter::RiskCalculator
 				fluids_present = (@cur_contact.is_self? || @person == person) &&
 					tracker.fluids_present?(@cur_contact)
 			else
-				tracker.track_after(@cur_contact, other_inst)
+				tracker.track_after(@cur_contact, other_inst, is_subject)
 			end
 		end
 		fluids_present

--- a/db/migrate/20200212102034_instrument_barriers.rb
+++ b/db/migrate/20200212102034_instrument_barriers.rb
@@ -1,0 +1,35 @@
+class InstrumentBarriers < Mongoid::Migration
+	def self.up
+		inst_barriers = {
+			hand: {
+				subject_barriers: [{ type: :glove }]
+			},
+			external_genitals: {
+				subject_barriers: [{ type: :condom }],
+				object_barriers: [{ type: :condom, conditions: [:can_penetrate], with_insts: [:mouth] }]
+			},
+			internal_genitals: {
+				object_barriers: [{ type: :condom }]
+			},
+			anus: {
+				object_barriers: [{ type: :condom }]
+			},
+			mouth: {
+				subject_barriers: [{ type: :dam }]
+			},
+			toy: {
+				subject_barriers: [{ type: :condom }, { type: :glove }]
+			}
+		}
+
+		inst_barriers.each do |inst_id, barrier_hash|
+			inst = Contact::Instrument.find(inst_id)
+			inst.update(barrier_hash)
+			inst.aliases.update(barrier_hash)
+		end
+	end
+
+	def self.down
+		Contact::Instrument.update(subject_barriers: nil, object_barriers: nil)
+	end
+end

--- a/spec/models/encounter/fluid_tracker_spec.rb
+++ b/spec/models/encounter/fluid_tracker_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Encounter::FluidTracker, type: :model do
 				contact = double("EncounterContact")
 
 				tracker = Encounter::FluidTracker.new(inst, :user)
-				tracker.track_after(contact, inst)
+				tracker.track_after(contact, inst, true)
 
 				expect(tracker.own_on_barrier).to be_empty
 				expect(tracker.other_on_barrier).to be_empty
@@ -74,11 +74,11 @@ RSpec.describe Encounter::FluidTracker, type: :model do
 		context 'with a barrier' do
 			context 'in a self-contact' do
 				it 'adds the other instrument alias name to @own_on_barrier' do
-					inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals, alias_of_id: :external_genitals)
+					inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals, alias_of_id: :external_genitals, subject_barriers: [{}])
 					contact = double("EncounterContact", {has_barrier?: true, is_self?: true})
 
 					tracker = Encounter::FluidTracker.new(inst, :user)
-					tracker.track_after(contact, inst)
+					tracker.track_after(contact, inst, true)
 
 					expect(tracker.own_on_barrier).to include(inst.alias_name)
 				end
@@ -86,11 +86,11 @@ RSpec.describe Encounter::FluidTracker, type: :model do
 
 			context 'in a partner contact' do
 				it 'adds the other instrument id to @other_on_barrier' do
-					inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals)
+					inst = build_stubbed(:contact_instrument, has_fluids: true, _id: :genitals, subject_barriers: [{}])
 					contact = double("EncounterContact", {has_barrier?: true, is_self?: false})
 
 					tracker = Encounter::FluidTracker.new(inst, :user)
-					tracker.track_after(contact, inst)
+					tracker.track_after(contact, inst, true)
 
 					expect(tracker.other_on_barrier).to include(inst._id)
 				end
@@ -104,7 +104,7 @@ RSpec.describe Encounter::FluidTracker, type: :model do
 					contact = double("EncounterContact", {has_barrier?: false, is_self?: true})
 
 					tracker = Encounter::FluidTracker.new(inst, :user)
-					tracker.track_after(contact, inst)
+					tracker.track_after(contact, inst, false)
 
 					expect(tracker.own_on_instrument).to include(inst._id)
 				end
@@ -116,7 +116,7 @@ RSpec.describe Encounter::FluidTracker, type: :model do
 					contact = double("EncounterContact", {has_barrier?: false, is_self?: false})
 
 					tracker = Encounter::FluidTracker.new(inst, :user)
-					tracker.track_after(contact, inst)
+					tracker.track_after(contact, inst, false)
 
 					expect(tracker.other_on_instrument).to include(inst._id)
 				end


### PR DESCRIPTION
Instead of assuming that a barrier could either be on the subject instrument or the object instrument in a given contact, the new system outlines what types of barriers are likely to associated with what instruments in what roles so that the barrier only follows the instruments it is likely to be reused with.